### PR TITLE
docs: fix typos

### DIFF
--- a/docs/src/miden_node_setup.md
+++ b/docs/src/miden_node_setup.md
@@ -1,6 +1,6 @@
 # Miden Node Setup Tutorial
 
-To run the Miden tutorial examples, you will need to set up a test enviorment and connect to a Miden node.
+To run the Miden tutorial examples, you will need to set up a test environment and connect to a Miden node.
 
 There are two ways to connect to a Miden node:
 
@@ -71,7 +71,7 @@ The endpoint of the Miden node running locally is:
 http://localhost:57123
 ```
 
-### Reseting the node
+### Resetting the node
 
 _If you need to reset the local state of the node run this command:_
 


### PR DESCRIPTION
noticed and corrected a couple of small typos:  
- "enviorment" → "environment"  
- "Reseting" → "Resetting"  
