### PR TITLE
chore: update dependencies & minor fixes

### DIFF
--- a/docs/src/rust-client/counter_contract_tutorial.md
+++ b/docs/src/rust-client/counter_contract_tutorial.md
@@ -36,7 +36,7 @@ miden-client = { version = "0.8.1", features = ["testing", "concurrent", "tonic"
 miden-lib = { version = "0.8", default-features = false }
 miden-objects = { version = "0.8", default-features = false }
 miden-crypto = { version = "0.14.0", features = ["executable"] }
-miden-assembly = "0.13.0"
+miden-assembly = "0.14.0"
 rand = { version = "0.9" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
@@ -175,6 +175,7 @@ export.get_count
     # => []
 end
 
+# => []
 export.increment_count
     push.0
     # => [index]

--- a/docs/src/rust-client/create_deploy_tutorial.md
+++ b/docs/src/rust-client/create_deploy_tutorial.md
@@ -47,7 +47,7 @@ miden-client = { version = "0.8.1", features = ["testing", "concurrent", "tonic"
 miden-lib = { version = "0.8", default-features = false }
 miden-objects = { version = "0.8", default-features = false }
 miden-crypto = { version = "0.14.0", features = ["executable"] }
-miden-assembly = "0.13.0"
+miden-assembly = "0.14.0"
 rand = { version = "0.9" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/docs/src/rust-client/creating_notes_in_masm_tutorial.md
+++ b/docs/src/rust-client/creating_notes_in_masm_tutorial.md
@@ -50,7 +50,7 @@ miden-client = { version = "0.8.1", features = ["testing", "concurrent", "tonic"
 miden-lib = { version = "0.8", default-features = false }
 miden-objects = { version = "0.8", default-features = false }
 miden-crypto = { version = "0.14.0", features = ["executable"] }
-miden-assembly = "0.13.0"
+miden-assembly = "0.14.0"
 rand = { version = "0.9" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/docs/src/rust-client/public_account_interaction_tutorial.md
+++ b/docs/src/rust-client/public_account_interaction_tutorial.md
@@ -36,7 +36,7 @@ miden-client = { version = "0.8.1", features = ["testing", "concurrent", "tonic"
 miden-lib = { version = "0.8", default-features = false }
 miden-objects = { version = "0.8", default-features = false }
 miden-crypto = { version = "0.14.0", features = ["executable"] }
-miden-assembly = "0.13.0"
+miden-assembly = "0.14.0"
 rand = { version = "0.9" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
@@ -81,6 +81,7 @@ export.get_count
     exec.sys::truncate_stack
 end
 
+# => []
 export.increment_count
     # => []
     push.0

--- a/masm/accounts/counter.masm
+++ b/masm/accounts/counter.masm
@@ -13,6 +13,7 @@ export.get_count
     # => []
 end
 
+# => []
 export.increment_count
     push.0
     # => [index]

--- a/rust-client/Cargo.lock
+++ b/rust-client/Cargo.lock
@@ -1221,7 +1221,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72269e041e915d6c34325a8906f08a8ff6ec9b92c79ae07f3a0de8c3588694b5"
 dependencies = [
- "miden-core",
+ "miden-core 0.13.0",
  "thiserror 2.0.12",
  "winter-air",
  "winter-prover",
@@ -1236,7 +1236,25 @@ dependencies = [
  "aho-corasick",
  "lalrpop",
  "lalrpop-util",
- "miden-core",
+ "miden-core 0.13.0",
+ "miden-miette",
+ "rustc_version 0.4.1",
+ "smallvec",
+ "thiserror 2.0.12",
+ "tracing",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
+name = "miden-assembly"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4e3d328e85faa193464dff6b51d9a6ede860a0a0b91858f2370931346d67c26"
+dependencies = [
+ "aho-corasick",
+ "lalrpop",
+ "lalrpop-util",
+ "miden-core 0.14.0",
  "miden-miette",
  "rustc_version 0.4.1",
  "smallvec",
@@ -1294,6 +1312,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "miden-core"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "134f716ca140dd0e89f5c96527c3554be1f0289f2519c905ac83a48f8db899a8"
+dependencies = [
+ "lock_api",
+ "loom",
+ "memchr",
+ "miden-crypto",
+ "miden-formatting",
+ "miden-miette",
+ "num-derive",
+ "num-traits",
+ "parking_lot",
+ "thiserror 2.0.12",
+ "winter-math",
+ "winter-utils",
+]
+
+[[package]]
 name = "miden-crypto"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1332,7 +1370,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea3fdad9ad0e50f71f4be0e27479d2de800a9b9262810d0cbedaea30e3f450b"
 dependencies = [
- "miden-assembly",
+ "miden-assembly 0.13.0",
  "miden-objects",
  "miden-stdlib",
  "regex",
@@ -1402,8 +1440,8 @@ checksum = "1ea350fdd6d025d2e4791ac0769bfbc04afca404fbb20f918354dcc758debd4c"
 dependencies = [
  "bech32",
  "getrandom 0.3.2",
- "miden-assembly",
- "miden-core",
+ "miden-assembly 0.13.0",
+ "miden-core 0.13.0",
  "miden-crypto",
  "miden-processor",
  "miden-verifier",
@@ -1423,7 +1461,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5f362138a7bfe6c20246de651e848566843a0d5062cc4a7a8ebff6bd14668d"
 dependencies = [
  "miden-air",
- "miden-core",
+ "miden-core 0.13.0",
  "thiserror 2.0.12",
  "tracing",
  "winter-prover",
@@ -1469,8 +1507,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "116d30a8db5167f88944509007b8bb7aad4fa0d9d03f2610b4e80be3a198ad37"
 dependencies = [
- "miden-assembly",
- "miden-core",
+ "miden-assembly 0.13.0",
+ "miden-core 0.13.0",
 ]
 
 [[package]]
@@ -1498,7 +1536,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ae6636d1e7a9d78a973fd59ffcfd87964eee235ecdf3264569add5ff89b0d91"
 dependencies = [
  "miden-air",
- "miden-core",
+ "miden-core 0.13.0",
  "thiserror 2.0.12",
  "tracing",
  "winter-verifier",
@@ -2133,7 +2171,7 @@ dependencies = [
 name = "rust-client"
 version = "0.1.0"
 dependencies = [
- "miden-assembly",
+ "miden-assembly 0.14.0",
  "miden-client",
  "miden-crypto",
  "miden-lib",

--- a/rust-client/Cargo.toml
+++ b/rust-client/Cargo.toml
@@ -8,7 +8,7 @@ miden-client = { version = "0.8.1", features = ["testing", "concurrent", "tonic"
 miden-lib = { version = "0.8", default-features = false }
 miden-objects = { version = "0.8", default-features = false }
 miden-crypto = { version = "0.14.0", features = ["executable"] }
-miden-assembly = "0.13.0"
+miden-assembly = "0.14.0"
 rand = { version = "0.9" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }


### PR DESCRIPTION
This PR updates the `miden-assembly` version used in the tutorials to the most recent version `0.14.0`. This PR also fixes small details in comments in MASM code. 