### PR TITLE
Update node setup guide

### DIFF
--- a/docs/src/miden_node_setup.md
+++ b/docs/src/miden_node_setup.md
@@ -9,26 +9,17 @@ There are two ways to connect to a Miden node:
 
 ## Running the Miden node locally
 
-### Step 1: Clone the miden-node repository
-
-In a terminal window, clone the miden-tutorials repository and navigate to the root of the repository using this command:
-
-```bash
-git clone git@github.com:0xPolygonMiden/miden-node.git
-cd miden-node
-```
-
-### Step 2: Install the Miden node
+### Step 1: Install the Miden node
 
 Next, install the miden-node crate using this command:
 
 ```bash
-make install-node
+cargo install miden-node --version 0.8.0
 ```
 
-### Step 3: Initializing the node
+### Step 2: Initializing the node
 
-To start the node, we first need to generate the genesis file. To do so, navigate to the `/node` directory and create the genesis file using this command:
+To start the node, we first need to generate the genesis file. Create the genesis file using this command:
 
 ```bash
 miden-node store dump-genesis > genesis.toml
@@ -45,14 +36,14 @@ Expected output:
 2025-04-16T18:05:30.049129Z  INFO miden_node::commands::store: bin/node/src/commands/store.rs:145: Generating account, index: 0, total: 1
 ```
 
-### Step 4: Starting the node
+### Step 3: Starting the node
 
 To start the node run this command:
 
 ```bash
 miden-node bundled start \
   --data-directory data \
-  --rpc.url http://0.0.0.0:57123
+  --rpc.url http://0.0.0.0:57291
 ```
 
 Expected output:
@@ -68,7 +59,7 @@ Congratulations, you now have a Miden node running locally. Now we can start cre
 The endpoint of the Miden node running locally is:
 
 ```
-http://localhost:57123
+http://localhost:57291
 ```
 
 ### Resetting the node
@@ -77,9 +68,10 @@ _If you need to reset the local state of the node run this command:_
 
 ```bash
 rm -r data
+rm -r accounts
 ```
 
-After resetting the state of the node, follow steps 3 and 4 again.
+After resetting the state of the node, follow steps 2 and 4 again.
 
 ## Connecting to the Miden testnet
 


### PR DESCRIPTION
This PR updates the node setup guide.

Changes:
1) Targets node version `0.8.0` specifically
2) Specify port `57291` as the port to run the localhost node
