### PR TITLE
Minor fixes & update counter contract id

### DIFF
--- a/docs/src/rust-client/counter_contract_tutorial.md
+++ b/docs/src/rust-client/counter_contract_tutorial.md
@@ -36,7 +36,7 @@ miden-client = { version = "0.8.1", features = ["testing", "concurrent", "tonic"
 miden-lib = { version = "0.8", default-features = false }
 miden-objects = { version = "0.8", default-features = false }
 miden-crypto = { version = "0.14.0", features = ["executable"] }
-miden-assembly = "0.14.0"
+miden-assembly = "0.13.0"
 rand = { version = "0.9" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/docs/src/rust-client/create_deploy_tutorial.md
+++ b/docs/src/rust-client/create_deploy_tutorial.md
@@ -47,7 +47,7 @@ miden-client = { version = "0.8.1", features = ["testing", "concurrent", "tonic"
 miden-lib = { version = "0.8", default-features = false }
 miden-objects = { version = "0.8", default-features = false }
 miden-crypto = { version = "0.14.0", features = ["executable"] }
-miden-assembly = "0.14.0"
+miden-assembly = "0.13.0"
 rand = { version = "0.9" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/docs/src/rust-client/creating_notes_in_masm_tutorial.md
+++ b/docs/src/rust-client/creating_notes_in_masm_tutorial.md
@@ -50,7 +50,7 @@ miden-client = { version = "0.8.1", features = ["testing", "concurrent", "tonic"
 miden-lib = { version = "0.8", default-features = false }
 miden-objects = { version = "0.8", default-features = false }
 miden-crypto = { version = "0.14.0", features = ["executable"] }
-miden-assembly = "0.14.0"
+miden-assembly = "0.13.0"
 rand = { version = "0.9" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
+++ b/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
@@ -210,7 +210,7 @@ Add this snippet to the end of your file in the `main()` function that we create
 println!("\n[STEP 2] Importing counter contract from public state");
 
 // Define the Counter Contract account id from counter contract deploy
-let counter_contract_id = AccountId::from_hex("0x104002887c1187000000ba20f61387").unwrap();
+let counter_contract_id = AccountId::from_hex("0x5fd8e3b9f4227200000581c6032f81").unwrap();
 
 client
     .import_account_by_id(counter_contract_id)
@@ -473,7 +473,7 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 2] Building counter contract from public state");
 
     // Define the Counter Contract account id from counter contract deploy
-    let counter_contract_id = AccountId::from_hex("0x104002887c1187000000ba20f61387").unwrap();
+    let counter_contract_id = AccountId::from_hex("0x5fd8e3b9f4227200000581c6032f81").unwrap();
 
     client
         .import_account_by_id(counter_contract_id)

--- a/docs/src/rust-client/public_account_interaction_tutorial.md
+++ b/docs/src/rust-client/public_account_interaction_tutorial.md
@@ -36,7 +36,7 @@ miden-client = { version = "0.8.1", features = ["testing", "concurrent", "tonic"
 miden-lib = { version = "0.8", default-features = false }
 miden-objects = { version = "0.8", default-features = false }
 miden-crypto = { version = "0.14.0", features = ["executable"] }
-miden-assembly = "0.14.0"
+miden-assembly = "0.13.0"
 rand = { version = "0.9" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
@@ -193,7 +193,7 @@ Add the following code snippet to the end of your `src/main.rs` function:
 println!("\n[STEP 1] Reading data from public state");
 
 // Define the Counter Contract account id from counter contract deploy
-let counter_contract_id = AccountId::from_hex("0x104002887c1187000000ba20f61387").unwrap();
+let counter_contract_id = AccountId::from_hex("0x5fd8e3b9f4227200000581c6032f81").unwrap();
 
 client
     .import_account_by_id(counter_contract_id)

--- a/rust-client/Cargo.lock
+++ b/rust-client/Cargo.lock
@@ -1221,7 +1221,7 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72269e041e915d6c34325a8906f08a8ff6ec9b92c79ae07f3a0de8c3588694b5"
 dependencies = [
- "miden-core 0.13.0",
+ "miden-core",
  "thiserror 2.0.12",
  "winter-air",
  "winter-prover",
@@ -1236,25 +1236,7 @@ dependencies = [
  "aho-corasick",
  "lalrpop",
  "lalrpop-util",
- "miden-core 0.13.0",
- "miden-miette",
- "rustc_version 0.4.1",
- "smallvec",
- "thiserror 2.0.12",
- "tracing",
- "unicode-width 0.2.0",
-]
-
-[[package]]
-name = "miden-assembly"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4e3d328e85faa193464dff6b51d9a6ede860a0a0b91858f2370931346d67c26"
-dependencies = [
- "aho-corasick",
- "lalrpop",
- "lalrpop-util",
- "miden-core 0.14.0",
+ "miden-core",
  "miden-miette",
  "rustc_version 0.4.1",
  "smallvec",
@@ -1297,7 +1279,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3af8faf28131caeae0b515ce227582e866f01ea3fd2a1772b7c125546f30068c"
 dependencies = [
- "miden-assembly 0.13.0",
+ "miden-assembly",
  "miden-client",
  "miden-crypto",
  "miden-lib",
@@ -1315,26 +1297,6 @@ name = "miden-core"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8ba125a31e9ec0e732f47e639525c753973e553126cfc46cc63674049ea4134"
-dependencies = [
- "lock_api",
- "loom",
- "memchr",
- "miden-crypto",
- "miden-formatting",
- "miden-miette",
- "num-derive",
- "num-traits",
- "parking_lot",
- "thiserror 2.0.12",
- "winter-math",
- "winter-utils",
-]
-
-[[package]]
-name = "miden-core"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134f716ca140dd0e89f5c96527c3554be1f0289f2519c905ac83a48f8db899a8"
 dependencies = [
  "lock_api",
  "loom",
@@ -1389,7 +1351,7 @@ version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ea3fdad9ad0e50f71f4be0e27479d2de800a9b9262810d0cbedaea30e3f450b"
 dependencies = [
- "miden-assembly 0.13.0",
+ "miden-assembly",
  "miden-objects",
  "miden-stdlib",
  "regex",
@@ -1459,8 +1421,8 @@ checksum = "1ea350fdd6d025d2e4791ac0769bfbc04afca404fbb20f918354dcc758debd4c"
 dependencies = [
  "bech32",
  "getrandom 0.3.2",
- "miden-assembly 0.13.0",
- "miden-core 0.13.0",
+ "miden-assembly",
+ "miden-core",
  "miden-crypto",
  "miden-processor",
  "miden-verifier",
@@ -1480,7 +1442,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5f362138a7bfe6c20246de651e848566843a0d5062cc4a7a8ebff6bd14668d"
 dependencies = [
  "miden-air",
- "miden-core 0.13.0",
+ "miden-core",
  "thiserror 2.0.12",
  "tracing",
  "winter-prover",
@@ -1526,8 +1488,8 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "116d30a8db5167f88944509007b8bb7aad4fa0d9d03f2610b4e80be3a198ad37"
 dependencies = [
- "miden-assembly 0.13.0",
- "miden-core 0.13.0",
+ "miden-assembly",
+ "miden-core",
 ]
 
 [[package]]
@@ -1555,7 +1517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ae6636d1e7a9d78a973fd59ffcfd87964eee235ecdf3264569add5ff89b0d91"
 dependencies = [
  "miden-air",
- "miden-core 0.13.0",
+ "miden-core",
  "thiserror 2.0.12",
  "tracing",
  "winter-verifier",
@@ -2190,7 +2152,7 @@ dependencies = [
 name = "rust-client"
 version = "0.1.0"
 dependencies = [
- "miden-assembly 0.14.0",
+ "miden-assembly",
  "miden-client",
  "miden-client-tools",
  "miden-crypto",

--- a/rust-client/Cargo.toml
+++ b/rust-client/Cargo.toml
@@ -8,7 +8,7 @@ miden-client = { version = "0.8.1", features = ["testing", "concurrent", "tonic"
 miden-lib = { version = "0.8", default-features = false }
 miden-objects = { version = "0.8", default-features = false }
 miden-crypto = { version = "0.14.0", features = ["executable"] }
-miden-assembly = "0.14.0"
+miden-assembly = "0.13.0"
 rand = { version = "0.9" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/rust-client/src/bin/counter_contract_fpi.rs
+++ b/rust-client/src/bin/counter_contract_fpi.rs
@@ -114,7 +114,7 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 2] Building counter contract from public state");
 
     // Define the Counter Contract account id from counter contract deploy
-    let counter_contract_id = AccountId::from_hex("0x104002887c1187000000ba20f61387").unwrap();
+    let counter_contract_id = AccountId::from_hex("0x5fd8e3b9f4227200000581c6032f81").unwrap();
 
     client
         .import_account_by_id(counter_contract_id)

--- a/rust-client/src/bin/counter_contract_increment.rs
+++ b/rust-client/src/bin/counter_contract_increment.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 1] Reading data from public state");
 
     // Define the Counter Contract account id from counter contract deploy
-    let counter_contract_id = AccountId::from_hex("0x104002887c1187000000ba20f61387").unwrap();
+    let counter_contract_id = AccountId::from_hex("0x5fd8e3b9f4227200000581c6032f81").unwrap();
 
     client
         .import_account_by_id(counter_contract_id)


### PR DESCRIPTION
This PR reverts the accidental update to use miden-assembly `0.14.0` & updates the counter contract id referenced to be `0x5fd8e3b9f4227200000581c6032f81`

https://testnet.midenscan.com/account/0x5fd8e3b9f4227200000581c6032f81