### PR TITLE
fix: fix tutorial text

### DIFF
--- a/docs/src/web-client/mint_consume_create_tutorial.md
+++ b/docs/src/web-client/mint_consume_create_tutorial.md
@@ -14,7 +14,7 @@ In the previous section, we initialized our repository and covered how to create
 
 ## Step 1: Minting tokens from the faucet
 
-To mint notes with tokens from the faucet we created, Alice can use the WebClient's `new_mint_transaction()` function.
+To mint notes with tokens from the faucet we created, Alice can use the WebClient's `newMintTransactionRequest()` function.
 
 Below is an example of a transaction request minting tokens from the faucet for Alice.
 
@@ -48,9 +48,9 @@ Once Alice has minted a note from the faucet, she will eventually want to spend 
 
 Minting a note from a faucet on Miden means a faucet account creates a new note targeted to the requesting account. The requesting account must consume this note for the assets to appear in their account.
 
-To identify notes that are ready to consume, the Miden WebClient has a useful function `get_consumable_notes`. It is also important to sync the state of the client before calling the `get_consumable_notes` function.
+To identify notes that are ready to consume, the Miden WebClient has a useful function `getConsumableNotes`. It is also important to sync the state of the client before calling the `getConsumableNotes` function.
 
-_Tip: If you know the expected number of notes after a transaction, use `await` or a loop condition to verify their availability before calling `get_consumable_notes`. This prevents unnecessary application idling._
+_Tip: If you know the expected number of notes after a transaction, use `await` or a loop condition to verify their availability before calling `getConsumableNotes`. This prevents unnecessary application idling._
 
 #### Identifying which notes are available:
 


### PR DESCRIPTION
Fixes references to old function names in the webclient.