### PR TITLE
Add oracle tutorial to exported.md

### DIFF
--- a/docs/src/EXPORTED.md
+++ b/docs/src/EXPORTED.md
@@ -13,6 +13,7 @@
     - [Foreign Procedure Invocation](./rust-client/foreign_procedure_invocation_tutorial.md)
     - [How to Use Unauthenticated Notes](./rust-client/unauthenticated_note_how_to.md)
     - [How to Use Mappings in Miden Assembly](./rust-client/mappings_in_masm_how_to.md)
+    - [Consuming On-Chain Price Data from the Pragma Oracle](imported/miden-tutorials/src/rust-client/oracle_tutorial.md)
   - [Web-Client](./web-client/about.md)
     - [Creating Accounts and Faucets](./web-client/create_deploy_tutorial.md)
     - [Mint, Consume, and Create Notes](./web-client/mint_consume_create_tutorial.md)


### PR DESCRIPTION
Adding the oracle tutorial to the `EXPORTED.md` file.