### PR TITLE
Update tutorials to use bech32 addresses

### DIFF
--- a/docs/src/rust-client/counter_contract_tutorial.md
+++ b/docs/src/rust-client/counter_contract_tutorial.md
@@ -65,7 +65,7 @@ use miden_client::{
     ClientError, Felt,
 };
 use miden_objects::{
-    account::AccountComponent, assembly::Assembler, assembly::DefaultSourceManager,
+    account::{AccountComponent, NetworkId}, assembly::Assembler, assembly::DefaultSourceManager,
 };
 
 fn create_library(
@@ -281,7 +281,10 @@ println!(
     "counter_contract commitment: {:?}",
     counter_contract.commitment()
 );
-println!("counter_contract id: {:?}", counter_contract.id().to_bech32(NetworkId::Testnet));
+println!(
+    "counter_contract id: {:?}",
+    counter_contract.id().to_bech32(NetworkId::Testnet)
+);
 println!("counter_contract storage: {:?}", counter_contract.storage());
 
 client
@@ -300,8 +303,8 @@ After the program executes, you should see the counter contract hash and contrac
 
 ```
 [STEP 1] Creating counter contract.
-counter_contract commitment: RpoDigest([6587363368733640299, 11199715422963228789, 4814068623617580858, 15157748550464046635])
-counter_contract id: "0x2add95df402ee300000027e1a3a003"
+counter_contract commitment: RpoDigest([10854804595308759734, 11034759279878416408, 15662010127375823242, 9560626040625797366])
+counter_contract id: "mtst1qpj0g3ke67tg5qqqqd2z4ffm9g8ezpf6"
 counter_contract storage: AccountStorage { slots: [Value([0, 0, 0, 0])] }
 ```
 
@@ -389,7 +392,7 @@ use miden_client::{
     ClientError, Felt,
 };
 use miden_objects::{
-    account::AccountComponent, assembly::Assembler, assembly::DefaultSourceManager,
+    account::{AccountComponent, NetworkId}, assembly::Assembler, assembly::DefaultSourceManager,
 };
 
 fn create_library(
@@ -430,7 +433,7 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 1] Creating counter contract.");
 
     // Load the MASM file for the counter contract
-    let counter_path = Path::new("../masm/accounts/counter.masm");
+    let counter_path = Path::new("./masm/accounts/counter.masm");
     let counter_code = fs::read_to_string(counter_path).unwrap();
 
     // Prepare assembler (debug mode = true)
@@ -470,7 +473,10 @@ async fn main() -> Result<(), ClientError> {
         "counter_contract commitment: {:?}",
         counter_contract.commitment()
     );
-    println!("counter_contract id: {:?}", counter_contract.id().to_bech32(NetworkId::Testnet));
+    println!(
+        "counter_contract id: {:?}",
+        counter_contract.id().to_bech32(NetworkId::Testnet)
+    );
     println!("counter_contract storage: {:?}", counter_contract.storage());
 
     client
@@ -484,7 +490,7 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 2] Call Counter Contract With Script");
 
     // Load the MASM script referencing the increment procedure
-    let script_path = Path::new("../masm/scripts/counter_script.masm");
+    let script_path = Path::new("./masm/scripts/counter_script.masm");
     let script_code = fs::read_to_string(script_path).unwrap();
 
     let assembler: Assembler = TransactionKernel::assembler().with_debug_mode(true);
@@ -539,15 +545,15 @@ async fn main() -> Result<(), ClientError> {
 The output of our program will look something like this:
 
 ```
-Latest block: 17590
+Latest block: 226717
 
 [STEP 1] Creating counter contract.
-counter_contract commitment: RpoDigest([13776863454932774952, 12657157213885349180, 12375803873150830068, 3663360040638123847])
-counter_contract id: "0xf11260152acd580000008bc429ccfe"
+counter_contract commitment: RpoDigest([10854804595308759734, 11034759279878416408, 15662010127375823242, 9560626040625797366])
+counter_contract id: "mtst1qpj0g3ke67tg5qqqqd2z4ffm9g8ezpf6"
 counter_contract storage: AccountStorage { slots: [Value([0, 0, 0, 0])] }
 
 [STEP 2] Call Counter Contract With Script
-Stack state before step 2505:
+Stack state before step 2502:
 ├──  0: 1
 ├──  1: 0
 ├──  2: 0
@@ -569,7 +575,7 @@ Stack state before step 2505:
 ├── 18: 0
 └── 19: 0
 
-View transaction on MidenScan: https://testnet.midenscan.com/tx/0x927fce258ee32df230edd2f56bc75d83ba844c9fd9a5e117f9bbaf0a30d3cd28
+View transaction on MidenScan: https://testnet.midenscan.com/tx/0x645b89ebf39c7baa2a4264854f793736b7370d65ecf5f1a23c0169fda6a6a395
 counter contract storage: Ok(RpoDigest([0, 0, 0, 1]))
 ```
 

--- a/docs/src/rust-client/counter_contract_tutorial.md
+++ b/docs/src/rust-client/counter_contract_tutorial.md
@@ -281,7 +281,7 @@ println!(
     "counter_contract commitment: {:?}",
     counter_contract.commitment()
 );
-println!("counter_contract id: {:?}", counter_contract.id().to_hex());
+println!("counter_contract id: {:?}", counter_contract.id().to_bech32(NetworkId::Testnet));
 println!("counter_contract storage: {:?}", counter_contract.storage());
 
 client
@@ -470,7 +470,7 @@ async fn main() -> Result<(), ClientError> {
         "counter_contract commitment: {:?}",
         counter_contract.commitment()
     );
-    println!("counter_contract id: {:?}", counter_contract.id().to_hex());
+    println!("counter_contract id: {:?}", counter_contract.id().to_bech32(NetworkId::Testnet));
     println!("counter_contract storage: {:?}", counter_contract.storage());
 
     client

--- a/docs/src/rust-client/create_deploy_tutorial.md
+++ b/docs/src/rust-client/create_deploy_tutorial.md
@@ -173,7 +173,7 @@ keystore
     .add_key(&AuthSecretKey::RpoFalcon512(key_pair))
     .unwrap();
 
-println!("Alice's account ID: {:?}", alice_account.id().to_hex());
+println!("Alice's account ID: {:?}", alice_account.id().to_bech32(NetworkId::Testnet));
 ```
 
 ## Step 4: Deploying a fungible faucet
@@ -222,7 +222,7 @@ keystore
     .add_key(&AuthSecretKey::RpoFalcon512(key_pair))
     .unwrap();
 
-println!("Faucet account ID: {:?}", faucet_account.id().to_hex());
+println!("Faucet account ID: {:?}", faucet_account.id().to_bech32(NetworkId::Testnet));
 
 // Resync to show newly deployed faucet
 client.sync_state().await?;
@@ -290,7 +290,7 @@ async fn main() -> Result<(), ClientError> {
         .add_key(&AuthSecretKey::RpoFalcon512(key_pair))
         .unwrap();
 
-    println!("Alice's account ID: {:?}", alice_account.id().to_hex());
+    println!("Alice's account ID: {:?}", alice_account.id().to_bech32(NetworkId::Testnet));
 
     //------------------------------------------------------------
     // STEP 2: Deploy a fungible faucet
@@ -329,7 +329,7 @@ async fn main() -> Result<(), ClientError> {
         .add_key(&AuthSecretKey::RpoFalcon512(key_pair))
         .unwrap();
 
-    println!("Faucet account ID: {:?}", faucet_account.id().to_hex());
+    println!("Faucet account ID: {:?}", faucet_account.id().to_bech32(NetworkId::Testnet));
 
     // Resync to show newly deployed faucet
     client.sync_state().await?;

--- a/docs/src/rust-client/creating_notes_in_masm_tutorial.md
+++ b/docs/src/rust-client/creating_notes_in_masm_tutorial.md
@@ -288,7 +288,7 @@ async fn wait_for_notes(
         println!(
             "{} consumable notes found for account {}. Waiting...",
             notes.len(),
-            account_id.id().to_hex()
+            account_id.id().to_bech32(NetworkId::Testnet)
         );
         sleep(Duration::from_secs(3)).await;
     }
@@ -319,13 +319,13 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Creating new accounts");
     let alice_account = create_basic_account(&mut client, keystore.clone()).await?;
-    println!("Alice's account ID: {:?}", alice_account.id().to_hex());
+    println!("Alice's account ID: {:?}", alice_account.id().to_bech32(NetworkId::Testnet));
     let bob_account = create_basic_account(&mut client, keystore.clone()).await?;
-    println!("Bob's account ID: {:?}", bob_account.id().to_hex());
+    println!("Bob's account ID: {:?}", bob_account.id().to_bech32(NetworkId::Testnet));
 
     println!("\nDeploying a new fungible faucet.");
     let faucet = create_basic_faucet(&mut client, keystore.clone()).await?;
-    println!("Faucet account ID: {:?}", faucet.id().to_hex());
+    println!("Faucet account ID: {:?}", faucet.id().to_bech32(NetworkId::Testnet));
     client.sync_state().await?;
 
     // -------------------------------------------------------------------------

--- a/docs/src/rust-client/creating_notes_in_masm_tutorial.md
+++ b/docs/src/rust-client/creating_notes_in_masm_tutorial.md
@@ -371,7 +371,7 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 3] Create iterative output note");
 
     let assembler = TransactionKernel::assembler().with_debug_mode(true);
-    let code = fs::read_to_string(Path::new("../masm/notes/iterative_output_note.masm")).unwrap();
+    let code = fs::read_to_string(Path::new("./masm/notes/iterative_output_note.masm")).unwrap();
     let rng = client.rng();
     let serial_num = rng.draw_word();
 
@@ -470,24 +470,25 @@ cargo run --release
 The output will look something like this:
 
 ```
-Latest block: 8153
+Latest block: 226933
 
 [STEP 1] Creating new accounts
-Alice's account ID: "0xf9919e334f7fa1100000d657ab75dc"
-Bob's account ID: "0xbd626b7bf785cd1000007d237250a1"
+Alice's account ID: "mtst1qpljtarjtawzcyqqqdcqu53adytw09yw"
+Bob's account ID: "mtst1qzaynsxth84vsyqqq0emse6ygcax3j59"
 
 Deploying a new fungible faucet.
-Faucet account ID: "0x8ac342a8684e72200000ce59224c27"
+Faucet account ID: "mtst1qpqpq6z8vrqvugqqqwjdnajgvurs9zgl"
 
 [STEP 2] Mint tokens with P2ID
-0 consumable notes found for account 0xf9919e334f7fa1100000d657ab75dc. Waiting...
+0 consumable notes found for account mtst1qpljtarjtawzcyqqqdcqu53adytw09yw. Waiting...
+0 consumable notes found for account mtst1qpljtarjtawzcyqqqdcqu53adytw09yw. Waiting...
 
 [STEP 3] Create iterative output note
-View transaction on MidenScan: https://testnet.midenscan.com/tx/0x6b47eab551fa1710587de34040e14070c8abd112e8f9725b5c10a022fe8809de
+View transaction on MidenScan: https://testnet.midenscan.com/tx/0x335061a434ccccbf9619052bdeacbc71b6e755b24f0ead0c3741a3b0954c78af
 
 [STEP 4] Bob consumes the note and creates a copy
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x5aa732e7cc7e226e7b66b0692a2b688f4cf20a6d6938d5ef82e05efa4d397d65
-Account delta: AccountVaultDelta { fungible: FungibleAssetDelta({V0(AccountIdV0 { prefix: 9998908888764543520, suffix: 226882222827264 }): 50}), non_fungible: NonFungibleAssetDelta({}) }
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xa39acf2bb965b4669b91bf564e8aa2987a9fc86ee350cd159ad5db1054cb67ab
+Account delta: AccountVaultDelta { fungible: FungibleAssetDelta({V0(Accoun
 ```
 
 ---

--- a/docs/src/rust-client/custom_note_how_to.md
+++ b/docs/src/rust-client/custom_note_how_to.md
@@ -280,7 +280,7 @@ async fn main() -> Result<(), ClientError> {
     println!("digest: {:?}", digest);
 
     let assembler = TransactionKernel::assembler().with_debug_mode(true);
-    let code = fs::read_to_string(Path::new("../masm/notes/hash_preimage_note.masm")).unwrap();
+    let code = fs::read_to_string(Path::new("./masm/notes/hash_preimage_note.masm")).unwrap();
     let serial_num = client.rng().draw_word();
     let note_script = NoteScript::compile(code, assembler).unwrap();
     let note_inputs = NoteInputs::new(digest.to_vec()).unwrap();
@@ -340,29 +340,29 @@ async fn main() -> Result<(), ClientError> {
 The output of our program will look something like this:
 
 ```
-Latest block: 8125
+Latest block: 226943
 
 [STEP 1] Creating new accounts
-Alice's account ID: "0x19e6170ade3f631000009993151abd"
-Bob's account ID: "0xba73b0bb92f3501000006d14c97ed1"
+Alice's account ID: "mtst1qqufkq3xr0rr5yqqqwgrc20ctythccy6"
+Bob's account ID: "mtst1qz76c9fvhvms2yqqqvvw8tf6m5h86y2h"
 
 Deploying a new fungible faucet.
-Faucet account ID: "0x4e9b048e422f4c200000b270fbf53c"
+Faucet account ID: "mtst1qpwsgjstpwvykgqqqwwzgz3u5vwuuywe"
 
 [STEP 2] Mint tokens with P2ID
-Note 0x2b581989b58d2256fb4d62955746d7bb5e100224498a2bc5ead4bed11beb1e23 not found. Waiting...
-Note 0x2b581989b58d2256fb4d62955746d7bb5e100224498a2bc5ead4bed11beb1e23 not found. Waiting...
-✅ note found 0x2b581989b58d2256fb4d62955746d7bb5e100224498a2bc5ead4bed11beb1e23
+Note 0x88d8c4a50c0e6342e58026b051fb6038867de21d3bd3963aec67fd6c45861faf not found. Waiting...
+Note 0x88d8c4a50c0e6342e58026b051fb6038867de21d3bd3963aec67fd6c45861faf not found. Waiting...
+✅ note found 0x88d8c4a50c0e6342e58026b051fb6038867de21d3bd3963aec67fd6c45861faf
 
 [STEP 3] Create custom note
 digest: RpoDigest([14371582251229115050, 1386930022051078873, 17689831064175867466, 9632123050519021080])
-note hash: "0x92d53905c422989284af4ad96a5821ce54294c8dc5f4bf45d05c363f6b3fec9f"
-View transaction on MidenScan: https://testnet.midenscan.com/tx/0xa5145ff24adc011bb4dd4da139b0d34402691d317cf0a4515337593d421a8f2f
+note hash: "0x14c66143377223e090e5b4da0d1e5ce6c6521622ad5b92161a704a25c915769b"
+View transaction on MidenScan: https://testnet.midenscan.com/tx/0xffbee228a2c6283efe958c6b3cd31af88018c029221b413b0f23fcfacb2cb611
 
 [STEP 4] Bob consumes the Custom Note with Correct Secret
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x10e061aacf029aa2a9ec0457d7ff23130ff859ae75ea9754cbac3f64a4d56659
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xe6c8bb7b469e03dcacd8f1f400011a781e96ad4266ede11af8e711379e85b929
 
-account delta: AccountVaultDelta { fungible: FungibleAssetDelta({V0(AccountIdV0 { prefix: 5664125965390793760, suffix: 196198333234176 }): 100}), non_fungible: NonFungibleAssetDelta({}) }
+account delta: AccountVaultDelta { fungible: FungibleAssetDelta({V0(AccountIdV0 { prefix: 6702563556733766432, suffix: 1016103534633728 }): 100}), non_fungible: NonFungibleAssetDelta({}) }
 ```
 
 ## Conclusion

--- a/docs/src/rust-client/custom_note_how_to.md
+++ b/docs/src/rust-client/custom_note_how_to.md
@@ -225,13 +225,13 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Creating new accounts");
     let alice_account = create_basic_account(&mut client, keystore.clone()).await?;
-    println!("Alice's account ID: {:?}", alice_account.id().to_hex());
+    println!("Alice's account ID: {:?}", alice_account.id().to_bech32(NetworkId::Testnet));
     let bob_account = create_basic_account(&mut client, keystore.clone()).await?;
-    println!("Bob's account ID: {:?}", bob_account.id().to_hex());
+    println!("Bob's account ID: {:?}", bob_account.id().to_bech32(NetworkId::Testnet));
 
     println!("\nDeploying a new fungible faucet.");
     let faucet = create_basic_faucet(&mut client, keystore).await?;
-    println!("Faucet account ID: {:?}", faucet.id().to_hex());
+    println!("Faucet account ID: {:?}", faucet.id().to_bech32(NetworkId::Testnet));
     client.sync_state().await?;
 
     // -------------------------------------------------------------------------

--- a/docs/src/rust-client/delegated_proving_tutorial.md
+++ b/docs/src/rust-client/delegated_proving_tutorial.md
@@ -100,7 +100,7 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     // import public faucet id
-    let faucet_id = AccountId::from_hex("0x9526e379bc3ad4200000b201b1f0f3").unwrap();
+    let (_, faucet_id) = AccountId::from_bech32("mtst1qrwx85wg0uyrqgqqqwty0s5xkujvszff").unwrap();
     client.import_account_by_id(faucet_id).await.unwrap();
     let binding = client.get_account(faucet_id).await.unwrap().unwrap();
     let faucet = binding.account();
@@ -179,11 +179,9 @@ cargo run --release
 The output will look like this:
 
 ```
-Latest block: 751265
-0 consumable notes found for account 0x33959f3ba0998010000ba4a311179b. Waiting...
-0 consumable notes found for account 0x33959f3ba0998010000ba4a311179b. Waiting...
-Alice Account balance: Ok(1000)
-Alice Account balance: Ok(900)
+Latest block: 226954
+Alice initial account balance: Ok(1000)
+Alice final account balance: Ok(900)
 ```
 
 ### Running the example

--- a/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
+++ b/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
@@ -168,7 +168,7 @@ async fn main() -> Result<(), ClientError> {
         "count_reader hash: {:?}",
         count_reader_contract.commitment()
     );
-    println!("contract id: {:?}", count_reader_contract.id().to_hex());
+    println!("contract id: {:?}", count_reader_contract.id().to_bech32(NetworkId::Testnet));
 
     client
         .add_account(
@@ -456,7 +456,7 @@ async fn main() -> Result<(), ClientError> {
         "count_reader hash: {:?}",
         count_reader_contract.commitment()
     );
-    println!("contract id: {:?}", count_reader_contract.id().to_hex());
+    println!("contract id: {:?}", count_reader_contract.id().to_bech32(NetworkId::Testnet));
 
     client
         .add_account(

--- a/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
+++ b/docs/src/rust-client/foreign_procedure_invocation_tutorial.md
@@ -103,8 +103,6 @@ end
 ### Step 3: Set up your `src/main.rs` file:
 
 ```rust
-
-
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client
@@ -128,7 +126,7 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 1] Creating count reader contract.");
 
     // Load the MASM file for the counter contract
-    let count_reader_path = Path::new("../masm/accounts/count_reader.masm");
+    let count_reader_path = Path::new("./masm/accounts/count_reader.masm");
     let count_reader_code = fs::read_to_string(count_reader_path).unwrap();
 
     // Prepare assembler (debug mode = true)
@@ -192,11 +190,11 @@ cargo run --release
 The output of our program will look something like this:
 
 ```
-Latest block: 17916
+Latest block: 226976
 
 [STEP 1] Creating count reader contract.
-count_reader hash: RpoDigest([17106452548071357259, 1177663122773866223, 12129142941281960455, 8269441041947541276])
-contract id: "0x4e79c8d2334239000000197081e311"
+count_reader hash: RpoDigest([15888177100833057221, 15548657445961063290, 5580812380698193124, 9604096693288041818])
+contract id: "mtst1qp3ca3adt34euqqqqwt488x34qnnd495"
 ```
 
 ## Step 4: Build and read the state of the counter contract deployed on testnet
@@ -205,12 +203,13 @@ Add this snippet to the end of your file in the `main()` function that we create
 
 ```rust
 // -------------------------------------------------------------------------
-// STEP 2: Import & Get State of the Counter Contract
+// STEP 2: Build & Get State of the Counter Contract
 // -------------------------------------------------------------------------
-println!("\n[STEP 2] Importing counter contract from public state");
+println!("\n[STEP 2] Building counter contract from public state");
 
 // Define the Counter Contract account id from counter contract deploy
-let counter_contract_id = AccountId::from_hex("0x5fd8e3b9f4227200000581c6032f81").unwrap();
+let (_, counter_contract_id) =
+    AccountId::from_bech32("mtst1qz4a33pfjn49qqqqq090u4g55upcas8t").unwrap();
 
 client
     .import_account_by_id(counter_contract_id)
@@ -230,7 +229,6 @@ let counter_contract = if let Some(account_record) = counter_contract_details {
 } else {
     panic!("Counter contract not found!");
 };
-
 ```
 
 This step uses the logic we explained in the [Public Account Interaction Tutorial](./public_account_interaction_tutorial.md) to read the state of the Counter contract and import it to the client locally.
@@ -245,7 +243,7 @@ Add this snippet to the end of your file in the `main()` function:
 // -------------------------------------------------------------------------
 println!("\n[STEP 3] Call counter contract with FPI from count copy contract");
 
-let counter_contract_path = Path::new("../masm/accounts/counter.masm");
+let counter_contract_path = Path::new("./masm/accounts/counter.masm");
 let counter_contract_code = fs::read_to_string(counter_contract_path).unwrap();
 
 let counter_contract_component =
@@ -277,7 +275,7 @@ println!("counter id prefix: {:?}", counter_contract.id().prefix());
 println!("suffix: {:?}", counter_contract.id().suffix());
 
 // Build the script that calls the count_copy_contract
-let script_path = Path::new("../masm/scripts/reader_script.masm");
+let script_path = Path::new("./masm/scripts/reader_script.masm");
 let script_code_original = fs::read_to_string(script_path).unwrap();
 let script_code = script_code_original
     .replace("{get_count_proc_hash}", &get_count_hash)
@@ -375,7 +373,8 @@ use miden_client::{
     ClientError, Felt,
 };
 use miden_objects::{
-    account::AccountComponent, assembly::Assembler, assembly::DefaultSourceManager,
+    account::{AccountComponent, NetworkId},
+    assembly::{Assembler, DefaultSourceManager},
 };
 
 fn create_library(
@@ -416,7 +415,7 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 1] Creating count reader contract.");
 
     // Load the MASM file for the counter contract
-    let count_reader_path = Path::new("../masm/accounts/count_reader.masm");
+    let count_reader_path = Path::new("./masm/accounts/count_reader.masm");
     let count_reader_code = fs::read_to_string(count_reader_path).unwrap();
 
     // Prepare assembler (debug mode = true)
@@ -456,7 +455,10 @@ async fn main() -> Result<(), ClientError> {
         "count_reader hash: {:?}",
         count_reader_contract.commitment()
     );
-    println!("contract id: {:?}", count_reader_contract.id().to_bech32(NetworkId::Testnet));
+    println!(
+        "contract id: {:?}",
+        count_reader_contract.id().to_bech32(NetworkId::Testnet)
+    );
 
     client
         .add_account(
@@ -473,7 +475,8 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 2] Building counter contract from public state");
 
     // Define the Counter Contract account id from counter contract deploy
-    let counter_contract_id = AccountId::from_hex("0xac6eeab35afb09000000ea9fae7722").unwrap();
+    let (_, counter_contract_id) =
+        AccountId::from_bech32("mtst1qz4a33pfjn49qqqqq090u4g55upcas8t").unwrap();
 
     client
         .import_account_by_id(counter_contract_id)
@@ -499,7 +502,7 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 3] Call counter contract with FPI from count copy contract");
 
-    let counter_contract_path = Path::new("../masm/accounts/counter.masm");
+    let counter_contract_path = Path::new("./masm/accounts/counter.masm");
     let counter_contract_code = fs::read_to_string(counter_contract_path).unwrap();
 
     let counter_contract_component =
@@ -531,7 +534,7 @@ async fn main() -> Result<(), ClientError> {
     println!("suffix: {:?}", counter_contract.id().suffix());
 
     // Build the script that calls the count_copy_contract
-    let script_path = Path::new("../masm/scripts/reader_script.masm");
+    let script_path = Path::new("./masm/scripts/reader_script.masm");
     let script_code_original = fs::read_to_string(script_path).unwrap();
     let script_code = script_code_original
         .replace("{get_count_proc_hash}", &get_count_hash)

--- a/docs/src/rust-client/mappings_in_masm_how_to.md
+++ b/docs/src/rust-client/mappings_in_masm_how_to.md
@@ -198,7 +198,7 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 1] Deploy a smart contract with a mapping");
 
     // Load the MASM file for the counter contract
-    let file_path = Path::new("../masm/accounts/mapping_example_contract.masm");
+    let file_path = Path::new("./masm/accounts/mapping_example_contract.masm");
     let account_code = fs::read_to_string(file_path).unwrap();
 
     // Prepare assembler (debug mode = true)
@@ -248,7 +248,7 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 2] Call Mapping Contract With Script");
 
     let script_code =
-        fs::read_to_string(Path::new("../masm/scripts/mapping_example_script.masm")).unwrap();
+        fs::read_to_string(Path::new("./masm/scripts/mapping_example_script.masm")).unwrap();
 
     // Create the library from the account source code using the helper function.
     let account_component_lib = create_library(

--- a/docs/src/rust-client/mint_consume_create_tutorial.md
+++ b/docs/src/rust-client/mint_consume_create_tutorial.md
@@ -258,7 +258,7 @@ use miden_client::{
     transaction::{OutputNote, PaymentTransactionData, TransactionRequestBuilder},
     ClientError, Felt,
 };
-use miden_objects::account::AccountIdVersion;
+use miden_objects::account::{AccountIdVersion, NetworkId};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -314,7 +314,10 @@ async fn main() -> Result<(), ClientError> {
         .add_key(&AuthSecretKey::RpoFalcon512(key_pair))
         .unwrap();
 
-    println!("Alice's account ID: {:?}", alice_account.id().to_bech32(NetworkId::Testnet));
+    println!(
+        "Alice's account ID: {:?}",
+        alice_account.id().to_bech32(NetworkId::Testnet)
+    );
 
     //------------------------------------------------------------
     // STEP 2: Deploy a fungible faucet
@@ -353,7 +356,10 @@ async fn main() -> Result<(), ClientError> {
         .add_key(&AuthSecretKey::RpoFalcon512(key_pair))
         .unwrap();
 
-    println!("Faucet account ID: {:?}", faucet_account.id().to_bech32(NetworkId::Testnet));
+    println!(
+        "Faucet account ID: {:?}",
+        faucet_account.id().to_bech32(NetworkId::Testnet)
+    );
 
     // Resync to show newly deployed faucet
     client.sync_state().await?;
@@ -499,15 +505,14 @@ async fn main() -> Result<(), ClientError> {
         alice_account.id(),
         target_account_id,
     );
-    let transaction_request = TransactionRequestBuilder::pay_to_id(
-        payment_transaction,
-        None,             // recall_height
-        NoteType::Public, // note type
-        client.rng(),     // rng
-    )
-    .unwrap()
-    .build()
-    .unwrap();
+    let transaction_request = TransactionRequestBuilder::new()
+        .build_pay_to_id(
+            payment_transaction,
+            None,             // recall_height
+            NoteType::Public, // note type
+            client.rng(),     // rng
+        )
+        .unwrap();
     let tx_execution_result = client
         .new_transaction(alice_account.id(), transaction_request)
         .await?;
@@ -532,13 +537,13 @@ cargo run --release
 The output will look like this:
 
 ```
-Latest block: 17795
+Latest block: 226896
 
 [STEP 1] Creating a new account for Alice
-Alice's account ID: "0xebc34ec1637352100000cb8699d5c0"
+Alice's account ID: "mtst1qp9czj052w3hvyqqqdtxmkh4myt45x2h"
 
 [STEP 2] Deploying a new fungible faucet.
-Faucet account ID: "0xd0736ee6005c0e200000d6f081f0ef"
+Faucet account ID: "mtst1qrn8x36uckhhvgqqqdze8g6t7ggyufq0"
 
 [STEP 3] Minting 5 notes of 100 tokens each for Alice.
 tx request built
@@ -554,7 +559,8 @@ Minted note #5 of 100 tokens for Alice.
 All 5 notes minted for Alice successfully!
 
 [STEP 4] Alice will now consume all of her notes to consolidate them.
-Currently, Alice has 3 consumable notes. Waiting...
+Currently, Alice has 2 consumable notes. Waiting...
+Currently, Alice has 4 consumable notes. Waiting...
 Found 5 consumable notes for Alice. Consuming them now...
 All of Alice's notes consumed successfully.
 

--- a/docs/src/rust-client/mint_consume_create_tutorial.md
+++ b/docs/src/rust-client/mint_consume_create_tutorial.md
@@ -314,7 +314,7 @@ async fn main() -> Result<(), ClientError> {
         .add_key(&AuthSecretKey::RpoFalcon512(key_pair))
         .unwrap();
 
-    println!("Alice's account ID: {:?}", alice_account.id().to_hex());
+    println!("Alice's account ID: {:?}", alice_account.id().to_bech32(NetworkId::Testnet));
 
     //------------------------------------------------------------
     // STEP 2: Deploy a fungible faucet
@@ -353,7 +353,7 @@ async fn main() -> Result<(), ClientError> {
         .add_key(&AuthSecretKey::RpoFalcon512(key_pair))
         .unwrap();
 
-    println!("Faucet account ID: {:?}", faucet_account.id().to_hex());
+    println!("Faucet account ID: {:?}", faucet_account.id().to_bech32(NetworkId::Testnet));
 
     // Resync to show newly deployed faucet
     client.sync_state().await?;

--- a/docs/src/rust-client/public_account_interaction_tutorial.md
+++ b/docs/src/rust-client/public_account_interaction_tutorial.md
@@ -238,10 +238,10 @@ Add the following code snippet to the end of your `src/main.rs` function:
 // -------------------------------------------------------------------------
 
 // Load the MASM script referencing the increment procedure
-let script_path = Path::new("../masm/scripts/counter_script.masm");
+let script_path = Path::new("./masm/scripts/counter_script.masm");
 let script_code = fs::read_to_string(script_path).unwrap();
 
-let counter_path = Path::new("../masm/accounts/counter.masm");
+let counter_path = Path::new("./masm/accounts/counter.masm");
 let counter_code = fs::read_to_string(counter_path).unwrap();
 
 let assembler: Assembler = TransactionKernel::assembler().with_debug_mode(true);

--- a/docs/src/rust-client/unauthenticated_note_how_to.md
+++ b/docs/src/rust-client/unauthenticated_note_how_to.md
@@ -123,7 +123,7 @@ async fn main() -> Result<(), ClientError> {
     client
         .add_account(&faucet_account, Some(seed), false)
         .await?;
-    println!("Faucet account ID: {}", faucet_account.id().to_hex());
+    println!("Faucet account ID: {}", faucet_account.id().to_bech32(NetworkId::Testnet));
 
     // Add the key pair to the keystore
     keystore
@@ -155,7 +155,7 @@ async fn main() -> Result<(), ClientError> {
 
         let (account, seed) = builder.build().unwrap();
         accounts.push(account.clone());
-        println!("account id {:?}: {}", i, account.id().to_hex());
+        println!("account id {:?}: {}", i, account.id().to_bech32(NetworkId::Testnet));
         client.add_account(&account, Some(seed), true).await?;
 
         // Add the key pair to the keystore
@@ -218,8 +218,8 @@ async fn main() -> Result<(), ClientError> {
     for i in 0..number_of_accounts - 1 {
         let loop_start = Instant::now();
         println!("\nunauthenticated tx {:?}", i + 1);
-        println!("sender: {}", accounts[i].id().to_hex());
-        println!("target: {}", accounts[i + 1].id().to_hex());
+        println!("sender: {}", accounts[i].id().to_bech32(NetworkId::Testnet));
+        println!("target: {}", accounts[i + 1].id().to_bech32(NetworkId::Testnet));
 
         // Time the creation of the p2id note
         let send_amount = 20;
@@ -301,7 +301,7 @@ async fn main() -> Result<(), ClientError> {
             .vault()
             .get_balance(faucet_account.id())
             .unwrap();
-        println!("Account: {} balance: {}", account.id().to_hex(), balance);
+        println!("Account: {} balance: {}", account.id().to_bech32(NetworkId::Testnet), balance);
     }
 
     Ok(())

--- a/docs/src/rust-client/unauthenticated_note_how_to.md
+++ b/docs/src/rust-client/unauthenticated_note_how_to.md
@@ -311,22 +311,22 @@ async fn main() -> Result<(), ClientError> {
 The output of our program will look something like this:
 
 ```
-Latest block: 17854
+Latest block: 227040
 
 [STEP 1] Deploying a new fungible faucet.
-Faucet account ID: 0x7a3c3e3e03fe43200000449196ce1f
+Faucet account ID: mtst1qqvhzywfzy4xugqqq0yqj28jxy3kr5hy
 
 [STEP 2] Creating new accounts
-account id 0: 0x44d89b438d298e1000003636aa7a58
-account id 1: 0xf275e0bcd03fd110000002b1cd6b60
-account id 2: 0xf18208694c7926100000d1946f306e
-account id 3: 0xc028077080d628100000f47f698791
-account id 4: 0x16c973d5b5cb96100000674ca476f9
-account id 5: 0x53ce6afddd744f100000b5d39c64bd
-account id 6: 0x3b8ed3bfa7c9f9100000dfd8a12b9c
-account id 7: 0x94117096753d06100000470857d9d2
-account id 8: 0xa8dd5dc6d59e89100000e620b17531
-account id 9: 0x3d0bdd225de2be1000004ffa75a2c1
+account id 0: mtst1qrdwf5hv6wnqzyqqq06hyfvqryn2nam3
+account id 1: mtst1qz7lwv4wh27xyyqqq026adcyc54ueccz
+account id 2: mtst1qzzmpa7f3tcnkyqqqdgj4dan2q8r0s6c
+account id 3: mtst1qrdclj0zp3v7qyqqqdn92ad87cl0rctl
+account id 4: mtst1qre79420whvn2yqqq0udf4z8d5c3xwfj
+account id 5: mtst1qpmfryrdjfwazyqqqdslm7gdhur80xhk
+account id 6: mtst1qr0n4cxfddn2wyqqqv2vsc9mnqh0dtyj
+account id 7: mtst1qrfmw4297mchwyqqqdfzq8dl2uu89uhq
+account id 8: mtst1qpevlxpnuetesyqqqdwmsgd4zua84nda
+account id 9: mtst1qre7lqnwt03zwyqqqvjdlj2w6yc87u4w
 
 [STEP 3] Mint tokens
 Minting tokens for Alice...
@@ -334,71 +334,71 @@ Minting tokens for Alice...
 [STEP 4] Create unauthenticated note tx chain
 
 unauthenticated tx 1
-sender: 0x44d89b438d298e1000003636aa7a58
-target: 0xf275e0bcd03fd110000002b1cd6b60
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x2eb9c92e928595a55c8d98027cb8f434dcaef15a6ce9478518ba8083f80d7928
-Total time for loop iteration 0: 3.126228875s
+sender: mtst1qrdwf5hv6wnqzyqqq06hyfvqryn2nam3
+target: mtst1qz7lwv4wh27xyyqqq026adcyc54ueccz
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x31f48117c645c5b4ccff78ef356bad764798d4f207925e492ebbae1b86ef4f55
+Total time for loop iteration 0: 1.952243542s
 
 unauthenticated tx 2
-sender: 0xf275e0bcd03fd110000002b1cd6b60
-target: 0xf18208694c7926100000d1946f306e
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x8e780ab4715d1473e7babcf05bef6550b9bbaca8dc9460cee3dd3e25bd1f097d
-Total time for loop iteration 1: 2.969214834s
+sender: mtst1qz7lwv4wh27xyyqqq026adcyc54ueccz
+target: mtst1qzzmpa7f3tcnkyqqqdgj4dan2q8r0s6c
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x45b4c62c6e8e79a1c7200d1c84dc6304a88debd37b20b069dd739498827354c1
+Total time for loop iteration 1: 2.091625458s
 
 unauthenticated tx 3
-sender: 0xf18208694c7926100000d1946f306e
-target: 0xc028077080d628100000f47f698791
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xdccd832ed22c9cd9054559d7746b5fe4cc9e78da50638e4a30973f4f0ea74e63
-Total time for loop iteration 2: 2.967574333s
+sender: mtst1qzzmpa7f3tcnkyqqqdgj4dan2q8r0s6c
+target: mtst1qrdclj0zp3v7qyqqqdn92ad87cl0rctl
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xb2241e10df8f6f891b910975a3b4f4fd47657c47de164138300d683cfca5dd61
+Total time for loop iteration 2: 1.846021291s
 
 unauthenticated tx 4
-sender: 0xc028077080d628100000f47f698791
-target: 0x16c973d5b5cb96100000674ca476f9
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xc8fe1dd90b9008861e4ea3583195edadefbb9443f657ae296dfba0bf4ac56519
-Total time for loop iteration 3: 2.86498225s
+sender: mtst1qrdclj0zp3v7qyqqqdn92ad87cl0rctl
+target: mtst1qre79420whvn2yqqq0udf4z8d5c3xwfj
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xd3ea6fa1da6c317f055ac4b069388d93b88d526039e01531879e75598e0f8cff
+Total time for loop iteration 3: 1.877627958s
 
 unauthenticated tx 5
-sender: 0x16c973d5b5cb96100000674ca476f9
-target: 0x53ce6afddd744f100000b5d39c64bd
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xaf4450834db4397de1832ea826c1fcecdf7fee0d8498110f857761e5f4c05bb6
-Total time for loop iteration 4: 2.879300125s
+sender: mtst1qre79420whvn2yqqq0udf4z8d5c3xwfj
+target: mtst1qpmfryrdjfwazyqqqdslm7gdhur80xhk
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x6098638ec0ff7331432c037331ee7372977abe20af5c56315985fd314e21548d
+Total time for loop iteration 4: 1.884586875s
 
 unauthenticated tx 6
-sender: 0x53ce6afddd744f100000b5d39c64bd
-target: 0x3b8ed3bfa7c9f9100000dfd8a12b9c
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xb5f3b92272ffde9a5e9634fe8e5ef9d0dc2dc6e1695f09685f5a80f143fef421
-Total time for loop iteration 5: 2.829184834s
+sender: mtst1qpmfryrdjfwazyqqqdslm7gdhur80xhk
+target: mtst1qr0n4cxfddn2wyqqqv2vsc9mnqh0dtyj
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x8258292e49e0cfdd96603450c2de6738afecb1e7482ede0fb68ea375e884e1d8
+Total time for loop iteration 5: 1.886505875s
 
 unauthenticated tx 7
-sender: 0x3b8ed3bfa7c9f9100000dfd8a12b9c
-target: 0x94117096753d06100000470857d9d2
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xed5eaba98132dd7bce4421da72cac330758ca41bd8818edb07526f7b662d8827
-Total time for loop iteration 6: 2.897448917s
+sender: mtst1qr0n4cxfddn2wyqqqv2vsc9mnqh0dtyj
+target: mtst1qrfmw4297mchwyqqqdfzq8dl2uu89uhq
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0x9e0f84e00a9393bf6e5f224d55ccdf8bd0ef32ee20c3299e2dfccf1771001dfd
+Total time for loop iteration 6: 2.095149458s
 
 unauthenticated tx 8
-sender: 0x94117096753d06100000470857d9d2
-target: 0xa8dd5dc6d59e89100000e620b17531
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xdd9cc26dbdbb542ef835780f9881708b9867190c353810ebce501955c5dad139
-Total time for loop iteration 7: 2.864668333s
+sender: mtst1qrfmw4297mchwyqqqdfzq8dl2uu89uhq
+target: mtst1qpevlxpnuetesyqqqdwmsgd4zua84nda
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xa9db6445dfaa44ccf9dd52bf4cd8d9057946571ccb5299a7a56c59faf2ed2093
+Total time for loop iteration 7: 1.935587291s
 
 unauthenticated tx 9
-sender: 0xa8dd5dc6d59e89100000e620b17531
-target: 0x3d0bdd225de2be1000004ffa75a2c1
-Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xdd6e35b59032c0a22ce1e8f27c43ee7935ec1c2077ff1c37444ded09b879c330
-Total time for loop iteration 8: 3.070943167s
+sender: mtst1qpevlxpnuetesyqqqdwmsgd4zua84nda
+target: mtst1qre7lqnwt03zwyqqqvjdlj2w6yc87u4w
+Consumed Note Tx on MidenScan: https://testnet.midenscan.com/tx/0xba4bb4ae3c7aaf949cdd3be8c9ea52169f958e7dca8e9d4541fd5ac939393e41
+Total time for loop iteration 8: 1.964682833s
 
-Total execution time for unauthenticated note txs: 26.46999025s
-blocks: [BlockNumber(17859), BlockNumber(17859), BlockNumber(17859), BlockNumber(17859), BlockNumber(17859), BlockNumber(17859), BlockNumber(17859), BlockNumber(17859), BlockNumber(17859)]
-Account: 0x44d89b438d298e1000003636aa7a58 balance: 80
-Account: 0xf275e0bcd03fd110000002b1cd6b60 balance: 0
-Account: 0xf18208694c7926100000d1946f306e balance: 0
-Account: 0xc028077080d628100000f47f698791 balance: 0
-Account: 0x16c973d5b5cb96100000674ca476f9 balance: 0
-Account: 0x53ce6afddd744f100000b5d39c64bd balance: 0
-Account: 0x3b8ed3bfa7c9f9100000dfd8a12b9c balance: 0
-Account: 0x94117096753d06100000470857d9d2 balance: 0
-Account: 0xa8dd5dc6d59e89100000e620b17531 balance: 0
-Account: 0x3d0bdd225de2be1000004ffa75a2c1 balance: 20
+Total execution time for unauthenticated note txs: 17.534611542s
+blocks: [BlockNumber(227047), BlockNumber(227047), BlockNumber(227047), BlockNumber(227047), BlockNumber(227047), BlockNumber(227047), BlockNumber(227047), BlockNumber(227047), BlockNumber(227047)]
+Account: mtst1qrdwf5hv6wnqzyqqq06hyfvqryn2nam3 balance: 80
+Account: mtst1qz7lwv4wh27xyyqqq026adcyc54ueccz balance: 0
+Account: mtst1qzzmpa7f3tcnkyqqqdgj4dan2q8r0s6c balance: 0
+Account: mtst1qrdclj0zp3v7qyqqqdn92ad87cl0rctl balance: 0
+Account: mtst1qre79420whvn2yqqq0udf4z8d5c3xwfj balance: 0
+Account: mtst1qpmfryrdjfwazyqqqdslm7gdhur80xhk balance: 0
+Account: mtst1qr0n4cxfddn2wyqqqv2vsc9mnqh0dtyj balance: 0
+Account: mtst1qrfmw4297mchwyqqqdfzq8dl2uu89uhq balance: 0
+Account: mtst1qpevlxpnuetesyqqqdwmsgd4zua84nda balance: 0
+Account: mtst1qre7lqnwt03zwyqqqvjdlj2w6yc87u4w balance: 20
 ```
 
 ## Conclusion

--- a/masm/accounts/oracle_reader.masm
+++ b/masm/accounts/oracle_reader.masm
@@ -11,7 +11,7 @@ export.get_price
     push.0xb86237a8c9cd35acfef457e47282cc4da43df676df410c988eab93095d8fb3b9
     # => [GET_MEDIAN_HASH, PAIR]
 
-    push.599064613630720.5721796415433354752
+    push.939716883672832.2172042075194638080
     # => [oracle_id_prefix, oracle_id_suffix, GET_MEDIAN_HASH, PAIR]
 
     exec.tx::execute_foreign_procedure

--- a/rust-client/src/bin/counter_contract_deploy.rs
+++ b/rust-client/src/bin/counter_contract_deploy.rs
@@ -15,6 +15,7 @@ use miden_client::{
 use miden_objects::{
     account::AccountComponent, assembly::Assembler, assembly::DefaultSourceManager,
 };
+use miden_objects::account::NetworkId;
 
 fn create_library(
     assembler: Assembler,
@@ -94,7 +95,7 @@ async fn main() -> Result<(), ClientError> {
         "counter_contract commitment: {:?}",
         counter_contract.commitment()
     );
-    println!("counter_contract id: {:?}", counter_contract.id().to_hex());
+    println!("counter_contract id: {:?}", counter_contract.id().to_bech32(NetworkId::Testnet));
     println!("counter_contract storage: {:?}", counter_contract.storage());
 
     client

--- a/rust-client/src/bin/counter_contract_deploy.rs
+++ b/rust-client/src/bin/counter_contract_deploy.rs
@@ -12,9 +12,10 @@ use miden_client::{
     transaction::{TransactionKernel, TransactionRequestBuilder, TransactionScript},
     ClientError, Felt,
 };
-use miden_objects::account::NetworkId;
 use miden_objects::{
-    account::AccountComponent, assembly::Assembler, assembly::DefaultSourceManager,
+    account::{AccountComponent, NetworkId},
+    assembly::Assembler,
+    assembly::DefaultSourceManager,
 };
 
 fn create_library(

--- a/rust-client/src/bin/counter_contract_deploy.rs
+++ b/rust-client/src/bin/counter_contract_deploy.rs
@@ -12,10 +12,10 @@ use miden_client::{
     transaction::{TransactionKernel, TransactionRequestBuilder, TransactionScript},
     ClientError, Felt,
 };
+use miden_objects::account::NetworkId;
 use miden_objects::{
     account::AccountComponent, assembly::Assembler, assembly::DefaultSourceManager,
 };
-use miden_objects::account::NetworkId;
 
 fn create_library(
     assembler: Assembler,
@@ -95,7 +95,10 @@ async fn main() -> Result<(), ClientError> {
         "counter_contract commitment: {:?}",
         counter_contract.commitment()
     );
-    println!("counter_contract id: {:?}", counter_contract.id().to_bech32(NetworkId::Testnet));
+    println!(
+        "counter_contract id: {:?}",
+        counter_contract.id().to_bech32(NetworkId::Testnet)
+    );
     println!("counter_contract storage: {:?}", counter_contract.storage());
 
     client

--- a/rust-client/src/bin/counter_contract_fpi.rs
+++ b/rust-client/src/bin/counter_contract_fpi.rs
@@ -16,7 +16,7 @@ use miden_client::{
     ClientError, Felt,
 };
 use miden_objects::{
-    account::AccountComponent, assembly::Assembler, assembly::DefaultSourceManager,
+    account::{AccountComponent, NetworkId}, assembly::{Assembler, DefaultSourceManager},
 };
 
 fn create_library(
@@ -97,7 +97,7 @@ async fn main() -> Result<(), ClientError> {
         "count_reader hash: {:?}",
         count_reader_contract.commitment()
     );
-    println!("contract id: {:?}", count_reader_contract.id().to_hex());
+    println!("contract id: {:?}", count_reader_contract.id().to_bech32(NetworkId::Testnet));
 
     client
         .add_account(
@@ -114,7 +114,7 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 2] Building counter contract from public state");
 
     // Define the Counter Contract account id from counter contract deploy
-    let counter_contract_id = AccountId::from_hex("0xac6eeab35afb09000000ea9fae7722").unwrap();
+    let (_, counter_contract_id) = AccountId::from_bech32("mtst1qz4a33pfjn49qqqqq090u4g55upcas8t").unwrap();
 
     client
         .import_account_by_id(counter_contract_id)

--- a/rust-client/src/bin/counter_contract_fpi.rs
+++ b/rust-client/src/bin/counter_contract_fpi.rs
@@ -16,7 +16,8 @@ use miden_client::{
     ClientError, Felt,
 };
 use miden_objects::{
-    account::{AccountComponent, NetworkId}, assembly::{Assembler, DefaultSourceManager},
+    account::{AccountComponent, NetworkId},
+    assembly::{Assembler, DefaultSourceManager},
 };
 
 fn create_library(
@@ -97,7 +98,10 @@ async fn main() -> Result<(), ClientError> {
         "count_reader hash: {:?}",
         count_reader_contract.commitment()
     );
-    println!("contract id: {:?}", count_reader_contract.id().to_bech32(NetworkId::Testnet));
+    println!(
+        "contract id: {:?}",
+        count_reader_contract.id().to_bech32(NetworkId::Testnet)
+    );
 
     client
         .add_account(
@@ -114,7 +118,8 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 2] Building counter contract from public state");
 
     // Define the Counter Contract account id from counter contract deploy
-    let (_, counter_contract_id) = AccountId::from_bech32("mtst1qz4a33pfjn49qqqqq090u4g55upcas8t").unwrap();
+    let (_, counter_contract_id) =
+        AccountId::from_bech32("mtst1qz4a33pfjn49qqqqq090u4g55upcas8t").unwrap();
 
     client
         .import_account_by_id(counter_contract_id)

--- a/rust-client/src/bin/counter_contract_increment.rs
+++ b/rust-client/src/bin/counter_contract_increment.rs
@@ -51,7 +51,7 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 1] Reading data from public state");
 
     // Define the Counter Contract account id from counter contract deploy
-    let counter_contract_id = AccountId::from_hex("0xac6eeab35afb09000000ea9fae7722").unwrap();
+    let (_, counter_contract_id) = AccountId::from_bech32("mtst1qz4a33pfjn49qqqqq090u4g55upcas8t").unwrap();
 
     client
         .import_account_by_id(counter_contract_id)

--- a/rust-client/src/bin/counter_contract_increment.rs
+++ b/rust-client/src/bin/counter_contract_increment.rs
@@ -51,7 +51,8 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 1] Reading data from public state");
 
     // Define the Counter Contract account id from counter contract deploy
-    let (_, counter_contract_id) = AccountId::from_bech32("mtst1qz4a33pfjn49qqqqq090u4g55upcas8t").unwrap();
+    let (_, counter_contract_id) =
+        AccountId::from_bech32("mtst1qz4a33pfjn49qqqqq090u4g55upcas8t").unwrap();
 
     client
         .import_account_by_id(counter_contract_id)

--- a/rust-client/src/bin/create_mint_consume_send.rs
+++ b/rust-client/src/bin/create_mint_consume_send.rs
@@ -17,7 +17,7 @@ use miden_client::{
     transaction::{OutputNote, PaymentTransactionData, TransactionRequestBuilder},
     ClientError, Felt,
 };
-use miden_objects::account::AccountIdVersion;
+use miden_objects::account::{AccountIdVersion, NetworkId};
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -73,7 +73,7 @@ async fn main() -> Result<(), ClientError> {
         .add_key(&AuthSecretKey::RpoFalcon512(key_pair))
         .unwrap();
 
-    println!("Alice's account ID: {:?}", alice_account.id().to_hex());
+    println!("Alice's account ID: {:?}", alice_account.id().to_bech32(NetworkId::Testnet));
 
     //------------------------------------------------------------
     // STEP 2: Deploy a fungible faucet
@@ -112,7 +112,7 @@ async fn main() -> Result<(), ClientError> {
         .add_key(&AuthSecretKey::RpoFalcon512(key_pair))
         .unwrap();
 
-    println!("Faucet account ID: {:?}", faucet_account.id().to_hex());
+    println!("Faucet account ID: {:?}", faucet_account.id().to_bech32(NetworkId::Testnet));
 
     // Resync to show newly deployed faucet
     client.sync_state().await?;

--- a/rust-client/src/bin/create_mint_consume_send.rs
+++ b/rust-client/src/bin/create_mint_consume_send.rs
@@ -73,7 +73,10 @@ async fn main() -> Result<(), ClientError> {
         .add_key(&AuthSecretKey::RpoFalcon512(key_pair))
         .unwrap();
 
-    println!("Alice's account ID: {:?}", alice_account.id().to_bech32(NetworkId::Testnet));
+    println!(
+        "Alice's account ID: {:?}",
+        alice_account.id().to_bech32(NetworkId::Testnet)
+    );
 
     //------------------------------------------------------------
     // STEP 2: Deploy a fungible faucet
@@ -112,7 +115,10 @@ async fn main() -> Result<(), ClientError> {
         .add_key(&AuthSecretKey::RpoFalcon512(key_pair))
         .unwrap();
 
-    println!("Faucet account ID: {:?}", faucet_account.id().to_bech32(NetworkId::Testnet));
+    println!(
+        "Faucet account ID: {:?}",
+        faucet_account.id().to_bech32(NetworkId::Testnet)
+    );
 
     // Resync to show newly deployed faucet
     client.sync_state().await?;

--- a/rust-client/src/bin/delegated_prover.rs
+++ b/rust-client/src/bin/delegated_prover.rs
@@ -39,7 +39,7 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
 
     // import public faucet id
-    let faucet_id = AccountId::from_hex("0x9526e379bc3ad4200000b201b1f0f3").unwrap();
+    let (_, faucet_id) = AccountId::from_bech32("mtst1qrwx85wg0uyrqgqqqwty0s5xkujvszff").unwrap();
     client.import_account_by_id(faucet_id).await.unwrap();
     let binding = client.get_account(faucet_id).await.unwrap().unwrap();
     let faucet = binding.account();

--- a/rust-client/src/bin/deploy_public_faucet.rs
+++ b/rust-client/src/bin/deploy_public_faucet.rs
@@ -3,7 +3,7 @@ use miden_client_tools::{
     create_basic_account, create_basic_faucet, delete_keystore_and_store, instantiate_client,
     mint_from_faucet_for_account,
 };
-
+use miden_objects::account::NetworkId;
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     delete_keystore_and_store(None).await;
@@ -21,7 +21,7 @@ async fn main() -> Result<(), ClientError> {
     let faucet = create_basic_faucet(&mut client, keystore.clone())
         .await
         .unwrap();
-    println!("faucetId: {:?}", faucet.id().to_hex());
+    println!("faucetId: {:?}", faucet.id().to_bech32(NetworkId::Testnet));
 
     // mint to publish faucet on chain
     let (alice_account, _) = create_basic_account(&mut client, keystore.clone())

--- a/rust-client/src/bin/hash_preimage_note.rs
+++ b/rust-client/src/bin/hash_preimage_note.rs
@@ -4,13 +4,25 @@ use tokio::time::{sleep, Duration};
 
 use miden_client::{
     account::{
-        component::{BasicFungibleFaucet, BasicWallet, RpoFalcon512}, Account, AccountBuilder, AccountId, AccountStorageMode, AccountType
-    }, asset::{FungibleAsset, TokenSymbol}, auth::AuthSecretKey, builder::ClientBuilder, crypto::{FeltRng, SecretKey}, keystore::FilesystemKeyStore, note::{
-        Note, NoteAssets, NoteExecutionHint, NoteExecutionMode, NoteInputs, NoteMetadata, NoteRecipient, NoteRelevance, NoteScript, NoteTag, NoteType
-    }, rpc::{Endpoint, TonicRpcClient}, store::InputNoteRecord, transaction::{OutputNote, TransactionKernel, TransactionRequestBuilder}, Client, ClientError, Felt, Word
+        component::{BasicFungibleFaucet, BasicWallet, RpoFalcon512},
+        Account, AccountBuilder, AccountId, AccountStorageMode, AccountType,
+    },
+    asset::{FungibleAsset, TokenSymbol},
+    auth::AuthSecretKey,
+    builder::ClientBuilder,
+    crypto::{FeltRng, SecretKey},
+    keystore::FilesystemKeyStore,
+    note::{
+        Note, NoteAssets, NoteExecutionHint, NoteExecutionMode, NoteInputs, NoteMetadata,
+        NoteRecipient, NoteRelevance, NoteScript, NoteTag, NoteType,
+    },
+    rpc::{Endpoint, TonicRpcClient},
+    store::InputNoteRecord,
+    transaction::{OutputNote, TransactionKernel, TransactionRequestBuilder},
+    Client, ClientError, Felt, Word,
 };
-use miden_objects::Hasher;
 use miden_objects::account::NetworkId;
+use miden_objects::Hasher;
 // Helper to create a basic account
 async fn create_basic_account(
     client: &mut Client,
@@ -110,13 +122,22 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Creating new accounts");
     let alice_account = create_basic_account(&mut client, keystore.clone()).await?;
-    println!("Alice's account ID: {:?}", alice_account.id().to_bech32(NetworkId::Testnet));
+    println!(
+        "Alice's account ID: {:?}",
+        alice_account.id().to_bech32(NetworkId::Testnet)
+    );
     let bob_account = create_basic_account(&mut client, keystore.clone()).await?;
-    println!("Bob's account ID: {:?}", bob_account.id().to_bech32(NetworkId::Testnet));
+    println!(
+        "Bob's account ID: {:?}",
+        bob_account.id().to_bech32(NetworkId::Testnet)
+    );
 
     println!("\nDeploying a new fungible faucet.");
     let faucet = create_basic_faucet(&mut client, keystore).await?;
-    println!("Faucet account ID: {:?}", faucet.id().to_bech32(NetworkId::Testnet));
+    println!(
+        "Faucet account ID: {:?}",
+        faucet.id().to_bech32(NetworkId::Testnet)
+    );
     client.sync_state().await?;
 
     // -------------------------------------------------------------------------
@@ -201,7 +222,7 @@ async fn main() -> Result<(), ClientError> {
     // STEP 4: Consume the Custom Note
     // -------------------------------------------------------------------------
     println!("\n[STEP 4] Bob consumes the Custom Note with Correct Secret");
-    
+
     let secret = [Felt::new(1), Felt::new(2), Felt::new(3), Felt::new(4)];
     let consume_custom_request = TransactionRequestBuilder::new()
         .with_unauthenticated_input_notes([(custom_note, Some(secret))])

--- a/rust-client/src/bin/hash_preimage_note.rs
+++ b/rust-client/src/bin/hash_preimage_note.rs
@@ -10,7 +10,7 @@ use miden_client::{
     }, rpc::{Endpoint, TonicRpcClient}, store::InputNoteRecord, transaction::{OutputNote, TransactionKernel, TransactionRequestBuilder}, Client, ClientError, Felt, Word
 };
 use miden_objects::Hasher;
-
+use miden_objects::account::NetworkId;
 // Helper to create a basic account
 async fn create_basic_account(
     client: &mut Client,
@@ -110,13 +110,13 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Creating new accounts");
     let alice_account = create_basic_account(&mut client, keystore.clone()).await?;
-    println!("Alice's account ID: {:?}", alice_account.id().to_hex());
+    println!("Alice's account ID: {:?}", alice_account.id().to_bech32(NetworkId::Testnet));
     let bob_account = create_basic_account(&mut client, keystore.clone()).await?;
-    println!("Bob's account ID: {:?}", bob_account.id().to_hex());
+    println!("Bob's account ID: {:?}", bob_account.id().to_bech32(NetworkId::Testnet));
 
     println!("\nDeploying a new fungible faucet.");
     let faucet = create_basic_faucet(&mut client, keystore).await?;
-    println!("Faucet account ID: {:?}", faucet.id().to_hex());
+    println!("Faucet account ID: {:?}", faucet.id().to_bech32(NetworkId::Testnet));
     client.sync_state().await?;
 
     // -------------------------------------------------------------------------

--- a/rust-client/src/bin/mapping_example.rs
+++ b/rust-client/src/bin/mapping_example.rs
@@ -16,6 +16,7 @@ use miden_objects::{
     account::{AccountComponent, StorageMap},
     assembly::Assembler,
     assembly::DefaultSourceManager,
+    
 };
 
 fn create_library(

--- a/rust-client/src/bin/mapping_example.rs
+++ b/rust-client/src/bin/mapping_example.rs
@@ -16,7 +16,6 @@ use miden_objects::{
     account::{AccountComponent, StorageMap},
     assembly::Assembler,
     assembly::DefaultSourceManager,
-    
 };
 
 fn create_library(

--- a/rust-client/src/bin/note_creation_in_masm.rs
+++ b/rust-client/src/bin/note_creation_in_masm.rs
@@ -21,6 +21,8 @@ use miden_client::{
     Client, ClientError, Felt,
 };
 
+use miden_objects::account::NetworkId;
+
 // Helper to create a basic account
 async fn create_basic_account(
     client: &mut Client,
@@ -84,7 +86,7 @@ async fn wait_for_notes(
         println!(
             "{} consumable notes found for account {}. Waiting...",
             notes.len(),
-            account_id.id().to_hex()
+            account_id.id().to_bech32(NetworkId::Testnet)
         );
         sleep(Duration::from_secs(3)).await;
     }
@@ -115,13 +117,13 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Creating new accounts");
     let alice_account = create_basic_account(&mut client, keystore.clone()).await?;
-    println!("Alice's account ID: {:?}", alice_account.id().to_hex());
+    println!("Alice's account ID: {:?}", alice_account.id().to_bech32(NetworkId::Testnet));
     let bob_account = create_basic_account(&mut client, keystore.clone()).await?;
-    println!("Bob's account ID: {:?}", bob_account.id().to_hex());
+    println!("Bob's account ID: {:?}", bob_account.id().to_bech32(NetworkId::Testnet));
 
     println!("\nDeploying a new fungible faucet.");
     let faucet = create_basic_faucet(&mut client, keystore.clone()).await?;
-    println!("Faucet account ID: {:?}", faucet.id().to_hex());
+    println!("Faucet account ID: {:?}", faucet.id().to_bech32(NetworkId::Testnet));
     client.sync_state().await?;
 
     // -------------------------------------------------------------------------

--- a/rust-client/src/bin/note_creation_in_masm.rs
+++ b/rust-client/src/bin/note_creation_in_masm.rs
@@ -117,13 +117,22 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Creating new accounts");
     let alice_account = create_basic_account(&mut client, keystore.clone()).await?;
-    println!("Alice's account ID: {:?}", alice_account.id().to_bech32(NetworkId::Testnet));
+    println!(
+        "Alice's account ID: {:?}",
+        alice_account.id().to_bech32(NetworkId::Testnet)
+    );
     let bob_account = create_basic_account(&mut client, keystore.clone()).await?;
-    println!("Bob's account ID: {:?}", bob_account.id().to_bech32(NetworkId::Testnet));
+    println!(
+        "Bob's account ID: {:?}",
+        bob_account.id().to_bech32(NetworkId::Testnet)
+    );
 
     println!("\nDeploying a new fungible faucet.");
     let faucet = create_basic_faucet(&mut client, keystore.clone()).await?;
-    println!("Faucet account ID: {:?}", faucet.id().to_bech32(NetworkId::Testnet));
+    println!(
+        "Faucet account ID: {:?}",
+        faucet.id().to_bech32(NetworkId::Testnet)
+    );
     client.sync_state().await?;
 
     // -------------------------------------------------------------------------

--- a/rust-client/src/bin/oracle_data_query.rs
+++ b/rust-client/src/bin/oracle_data_query.rs
@@ -85,7 +85,7 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     // Get all foreign accounts for oracle data
     // -------------------------------------------------------------------------
-    let oracle_account_id = AccountId::from_hex("0x4f67e78643022e00000220d8997e33").unwrap();
+    let (_, oracle_account_id) = AccountId::from_bech32("mtst1qq0zffxzdykm7qqqqdt24cc2du5ghx99").unwrap();
     let btc_usd_pair_id = 120195681;
     let foreign_accounts: Vec<ForeignAccount> =
         get_oracle_foreign_accounts(&mut client, oracle_account_id, btc_usd_pair_id).await?;

--- a/rust-client/src/bin/oracle_data_query.rs
+++ b/rust-client/src/bin/oracle_data_query.rs
@@ -85,7 +85,8 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     // Get all foreign accounts for oracle data
     // -------------------------------------------------------------------------
-    let (_, oracle_account_id) = AccountId::from_bech32("mtst1qq0zffxzdykm7qqqqdt24cc2du5ghx99").unwrap();
+    let (_, oracle_account_id) =
+        AccountId::from_bech32("mtst1qq0zffxzdykm7qqqqdt24cc2du5ghx99").unwrap();
     let btc_usd_pair_id = 120195681;
     let foreign_accounts: Vec<ForeignAccount> =
         get_oracle_foreign_accounts(&mut client, oracle_account_id, btc_usd_pair_id).await?;

--- a/rust-client/src/bin/unauthenticated_note_transfer.rs
+++ b/rust-client/src/bin/unauthenticated_note_transfer.rs
@@ -73,7 +73,10 @@ async fn main() -> Result<(), ClientError> {
     client
         .add_account(&faucet_account, Some(seed), false)
         .await?;
-    println!("Faucet account ID: {}", faucet_account.id().to_bech32(NetworkId::Testnet));
+    println!(
+        "Faucet account ID: {}",
+        faucet_account.id().to_bech32(NetworkId::Testnet)
+    );
 
     // Add the key pair to the keystore
     keystore
@@ -105,7 +108,11 @@ async fn main() -> Result<(), ClientError> {
 
         let (account, seed) = builder.build().unwrap();
         accounts.push(account.clone());
-        println!("account id {:?}: {}", i, account.id().to_bech32(NetworkId::Testnet));
+        println!(
+            "account id {:?}: {}",
+            i,
+            account.id().to_bech32(NetworkId::Testnet)
+        );
         client.add_account(&account, Some(seed), true).await?;
 
         // Add the key pair to the keystore
@@ -169,7 +176,10 @@ async fn main() -> Result<(), ClientError> {
         let loop_start = Instant::now();
         println!("\nunauthenticated tx {:?}", i + 1);
         println!("sender: {}", accounts[i].id().to_bech32(NetworkId::Testnet));
-        println!("target: {}", accounts[i + 1].id().to_bech32(NetworkId::Testnet));
+        println!(
+            "target: {}",
+            accounts[i + 1].id().to_bech32(NetworkId::Testnet)
+        );
 
         // Time the creation of the p2id note
         let send_amount = 20;
@@ -252,7 +262,11 @@ async fn main() -> Result<(), ClientError> {
             .vault()
             .get_balance(faucet_account.id())
             .unwrap();
-        println!("Account: {} balance: {}", account.id().to_bech32(NetworkId::Testnet), balance);
+        println!(
+            "Account: {} balance: {}",
+            account.id().to_bech32(NetworkId::Testnet),
+            balance
+        );
     }
 
     Ok(())

--- a/rust-client/src/bin/unauthenticated_note_transfer.rs
+++ b/rust-client/src/bin/unauthenticated_note_transfer.rs
@@ -18,7 +18,7 @@ use miden_client::{
     utils::{Deserializable, Serializable},
     ClientError, Felt,
 };
-
+use miden_objects::account::NetworkId;
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
     // Initialize client & keystore
@@ -73,7 +73,7 @@ async fn main() -> Result<(), ClientError> {
     client
         .add_account(&faucet_account, Some(seed), false)
         .await?;
-    println!("Faucet account ID: {}", faucet_account.id().to_hex());
+    println!("Faucet account ID: {}", faucet_account.id().to_bech32(NetworkId::Testnet));
 
     // Add the key pair to the keystore
     keystore
@@ -105,7 +105,7 @@ async fn main() -> Result<(), ClientError> {
 
         let (account, seed) = builder.build().unwrap();
         accounts.push(account.clone());
-        println!("account id {:?}: {}", i, account.id().to_hex());
+        println!("account id {:?}: {}", i, account.id().to_bech32(NetworkId::Testnet));
         client.add_account(&account, Some(seed), true).await?;
 
         // Add the key pair to the keystore
@@ -168,8 +168,8 @@ async fn main() -> Result<(), ClientError> {
     for i in 0..number_of_accounts - 1 {
         let loop_start = Instant::now();
         println!("\nunauthenticated tx {:?}", i + 1);
-        println!("sender: {}", accounts[i].id().to_hex());
-        println!("target: {}", accounts[i + 1].id().to_hex());
+        println!("sender: {}", accounts[i].id().to_bech32(NetworkId::Testnet));
+        println!("target: {}", accounts[i + 1].id().to_bech32(NetworkId::Testnet));
 
         // Time the creation of the p2id note
         let send_amount = 20;
@@ -252,7 +252,7 @@ async fn main() -> Result<(), ClientError> {
             .vault()
             .get_balance(faucet_account.id())
             .unwrap();
-        println!("Account: {} balance: {}", account.id().to_hex(), balance);
+        println!("Account: {} balance: {}", account.id().to_bech32(NetworkId::Testnet), balance);
     }
 
     Ok(())


### PR DESCRIPTION
This PR updates the rust client tutorial code and tutorial markdown files to use bech32 address formats. 

Resolves #68 