### PR TITLE
chore: bring back runnable tests: final test only

### DIFF
--- a/docs/src/rust-client/counter_contract_tutorial.md
+++ b/docs/src/rust-client/counter_contract_tutorial.md
@@ -551,7 +551,7 @@ println!(
 
 The final `src/main.rs` file should look like this:
 
-```rust,no_run
+```rust
 use miden_lib::account::auth::NoAuth;
 use rand::RngCore;
 use std::{fs, path::Path, sync::Arc};

--- a/docs/src/rust-client/create_deploy_tutorial.md
+++ b/docs/src/rust-client/create_deploy_tutorial.md
@@ -358,7 +358,7 @@ _When tokens are minted from this faucet, each token batch is represented as a "
 
 Your updated `main()` function in `src/main.rs` should look like this:
 
-```rust,no_run
+```rust
 use rand::RngCore;
 use std::sync::Arc;
 use tokio::time::Duration;

--- a/docs/src/rust-client/creating_notes_in_masm_tutorial.md
+++ b/docs/src/rust-client/creating_notes_in_masm_tutorial.md
@@ -201,7 +201,7 @@ With the Miden assembly note script written, we can move on to writing the Rust 
 
 Copy and paste the following code into your `src/main.rs` file.
 
-```rust,no_run
+```rust
 use miden_lib::account::auth::AuthRpoFalcon512;
 use rand::{prelude::StdRng, RngCore};
 use std::{fs, path::Path, sync::Arc};

--- a/docs/src/rust-client/custom_note_how_to.md
+++ b/docs/src/rust-client/custom_note_how_to.md
@@ -128,7 +128,7 @@ With the note created, Bob can now consume it—but only if he provides the corr
 
 The following Rust code demonstrates how to implement the steps outlined above using the Miden client library:
 
-```rust,no_run
+```rust
 use miden_lib::account::auth::AuthRpoFalcon512;
 use rand::{rngs::StdRng, RngCore};
 use std::{fs, path::Path, sync::Arc};

--- a/docs/src/rust-client/delegated_proving_tutorial.md
+++ b/docs/src/rust-client/delegated_proving_tutorial.md
@@ -57,7 +57,7 @@ rand_chacha = "0.9.0"
 Similarly to previous tutorials, we must instantiate the client.
 We construct a `RemoteTransactionProver` that points to our delegated-proving service running at https://tx-prover.testnet.miden.io.
 
-```rust,no_run
+```rust
 use miden_client::auth::AuthSecretKey;
 use std::sync::Arc;
 

--- a/docs/src/rust-client/mappings_in_masm_how_to.md
+++ b/docs/src/rust-client/mappings_in_masm_how_to.md
@@ -135,7 +135,7 @@ The script calls the `write_to_map` procedure in the account which writes the ke
 
 Below is the Rust code that deploys the smart contract, creates the transaction script, and submits a transaction to update the mapping in the account:
 
-```rust,no_run
+```rust
 use rand::RngCore;
 use std::{fs, path::Path, sync::Arc};
 

--- a/docs/src/rust-client/mint_consume_create_tutorial.md
+++ b/docs/src/rust-client/mint_consume_create_tutorial.md
@@ -984,7 +984,7 @@ Note: _In a production environment do not use `AccountId::new_dummy()`, this is 
 
 Your `src/main.rs` function should now look like this:
 
-```rust,no_run
+```rust
 use rand::RngCore;
 use std::sync::Arc;
 use tokio::time::Duration;

--- a/docs/src/rust-client/network_transactions_tutorial.md
+++ b/docs/src/rust-client/network_transactions_tutorial.md
@@ -1048,7 +1048,7 @@ This step creates a public note that the network operator can consume to execute
 
 Your complete `main()` function should look like this:
 
-```rust,no_run
+```rust
 use std::{fs, path::Path, sync::Arc};
 
 use miden_client::{

--- a/docs/src/rust-client/public_account_interaction_tutorial.md
+++ b/docs/src/rust-client/public_account_interaction_tutorial.md
@@ -435,7 +435,7 @@ println!(
 
 The final `src/main.rs` file should look like this:
 
-```rust,no_run
+```rust
 use std::{fs, path::Path, sync::Arc};
 
 use miden_assembly::{

--- a/docs/src/rust-client/unauthenticated_note_how_to.md
+++ b/docs/src/rust-client/unauthenticated_note_how_to.md
@@ -47,7 +47,7 @@ Alice ➡ Bob ➡ Charlie ➡ Dave ➡ Eve ➡ Frank ➡ ...
 
 ## Full Rust code example
 
-```rust,no_run
+```rust
 use rand::RngCore;
 use std::sync::Arc;
 use tokio::time::{Duration, Instant};


### PR DESCRIPTION
to speed things up, the intermediate tests are still marked as `no_run` - only the final / summary test is runnable (except for FPI, created #123 for that)

it's still useful to keep the intermediate tests with `no_run` because they still get compiled which can surface potential issues with the tutorials